### PR TITLE
Fix issue with nbforce.setParticleParameters() in example

### DIFF
--- a/tutorials/alchemical-free-energy/files/alchemical-example.py
+++ b/tutorials/alchemical-free-energy/files/alchemical-example.py
@@ -32,7 +32,7 @@ for index in range(system.getNumParticles()):
     [charge, sigma, epsilon] = nbforce.getParticleParameters(index)
     custom_force.addParticle([sigma, epsilon])
     if index in alchemical_particles:
-        nbforce.setParticleParameters(index, charge*0, sigma, epsilon*0)
+        nbforce.setParticleParameters(index, charge*0, sigma, epsilon)
 custom_force.addInteractionGroup(alchemical_particles, chemical_particles)
 system.addForce(custom_force)
 

--- a/tutorials/alchemical-free-energy/index.md
+++ b/tutorials/alchemical-free-energy/index.md
@@ -59,7 +59,7 @@ for index in range(system.getNumParticles()):
     [charge, sigma, epsilon] = nbforce.getParticleParameters(index)
     custom_force.addParticle([sigma, epsilon])
     if index in alchemical_particles:
-        nbforce.setParticleParameters(index, charge*0, sigma, epsilon*0)
+        nbforce.setParticleParameters(index, charge*0, sigma, epsilon)
 custom_force.addInteractionGroup(alchemical_particles, chemical_particles)
 system.addForce(custom_force)
 ```


### PR DESCRIPTION
I have been exploring/debugging a few tools in and around [Yank](https://github.com/choderalab/yank/) in an aid to improve my general understanding of the workflow.

Around the beginning of the year, I was experimenting with the LJ example, alchemical-example.py, on http://openmm.org/tutorials/alchemical-free-energy/ . I was trying help a student with some examples of free energy calculations within OpenMM. The example would sometimes work, sometimes fail with the pymbar error:
```
 "Failing with “pymbar.utils.ParameterError: Warning: Should have \sum_n W_nk = 1.”.
```
I had assumed that this was a sampling issue and/or some unknown bug in pymbar and this assumption was reinforced by this recent issue in Yank discussed here https://github.com/choderalab/yank/pull/1216 .




However, recently, I decided to revisit this and I discovered that sometimes, the system's potential energy would be massive. This was stochastic over many runs. I had assumed the single precision floating point representation was the problem in the beginning.

But.... digging in, I discovered a possible bug in the alchemical-example.py script:
```
    nbforce.setParticleParameters(index, charge*0, sigma, epsilon*0)
```
should be:
```
    nbforce.setParticleParameters(index, charge*0, sigma, epsilon)
```
This solves the issue.
