### PR TITLE
Update readme for new website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,19 @@
-OpenMM.org website
-==================
+# OpenMM.org website
 
-Travis-CI build status: [![Build Status](https://travis-ci.org/openmm/openmm-org.svg?branch=master)](https://travis-ci.org/openmm/openmm-org)
-
-This repository contains the code for the generation of the static http://openmm.org
-website. The site provides a description of the project
-and serves links to documentation, downloads, videos, etc. The development of the
+This repository contains the code for the generation of the static
+http://openmm.org website. The site provides a description of the project and
+serves links to documentation, downloads, videos, etc. The development of the
 OpenMM project itself takes place at https://github.com/openmm/openmm
 
-The site is deployed to the `openmm.org` S3 bucket managed through the Pande Group AWS
-account. The site should be automatically re-generated and uploaded using Travis CI with
-each commit to the master branch of this repository.
+The site uses the [Vue.js](https://vuejs.org/) framework, and so does not need
+any static site generator to edit. The `master` branch is deployed automatically to https://openmm.org via GitHub Pages.
 
-Writing a page
---------------
+## Development
 
-Each page should include Jekyll "front-matter" which describes the page.
-For example,
+Fork the repository on GitHub and clone locally. To view the website produced by
+a local copy, serve the folder via a simple HTTP server; for example:
 
-    ---
-    title: OpenMM Documentation
-    layout: page
-    ---
-
-sets the jekyll "layout" to `page` and sets the HTML title attribute
-to "OpenMM Documentation". We provide these layouts:
-
- - `page`: A basic bootstrap template. You're reponsible for almost everything
-   in the `<body>` tag. This layout includes css and js files, and appends a
-   footer to the end of the body. If you're using this layout, you should be
-   writing html. Historical note: This site used to be completely static
-   (ie not generated). This layout comprised a minimal refactoring. You could
-   probably make it more elegant if you're inclined to do so.
- - `nicepage`: This sets up bootstrap containers and a nice heading. Additional
-   front-matter options includes `lead` which will add some text to the heading
-   block. Use this layout if you're writing markdown.
-
-
-Building locally
-----------------
-
-You can follow the [Github pages documentation](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/), although we don't use Github pages per se.
-
-Install ruby which gives you `gem`. Use that to install `bundler`
-
-```bash
-gem install bundler           # install dependency manager
-bundle install                # Install dependencies
-bundle exec jekyll serve      # Build and serve the site
+```shell
+npm install -g http-server
+http-server
 ```
-
-That final command seems needlessly complicated. Use the included
-`jekyll.sh` so you don't have to remember it.
-
-Pushing to the preview site
----------------------------
-
-Merge your changes to the `preview` branch to automatically build and push to the preview site, located at
-http://openmm.org/preview
-
-When satisfied with the preview, merge your changes from `preview` into the `master` branch to automatically push to the main live site http://openmm.org


### PR DESCRIPTION
Prior to this PR, the readme had not been updated to describe the new Vue-based website. This PR updates the readme to include simple instructions on how to edit and preview the site, and to remove outdated references to Jekyll.