### PR TITLE
drop simtk from main page example

### DIFF
--- a/data/example.py
+++ b/data/example.py
@@ -1,6 +1,6 @@
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 from sys import stdout
 
 pdb = PDBFile('input.pdb')


### PR DESCRIPTION
While dealing with the unwrapping of the namespace for OpenMM >= 7.6, I noticed that the example on the webpage still uses the old style imports.

This drops the simtk package from the example on the website