### PR TITLE
Add links to older docs versions

### DIFF
--- a/components/documentation.vue
+++ b/components/documentation.vue
@@ -165,7 +165,6 @@
           The C++ API provides information about OpenMM's C++ interface.
         </v-card-text>
       </v-card>
-
       <v-card href="https://openmm.github.io/openmm-cookbook/dev/cookbook" target="blank" class="ma-4" width="300" hover>
         <v-card-title>Cookbook (dev)</v-card-title>
         <v-card-text>
@@ -177,7 +176,29 @@
         <v-card-text>
           Tutorials for getting started with and exploring OpenMM.
         </v-card-text>
+      </v-card>
     </v-container>
+    <v-container>
+      <v-card flat>
+        <v-card-title>All Documentation versions</v-card-title>
+        <v-card-text>
+           Here you can find all available older documentation versions.
+           The latest stable release is {{ versions.latest }}.
+        </v-card-text>
+      </v-card>
+      <v-card v-for="version of versions.versions" target="blank" class="ma-2">
+        <v-card-title>{{ version.name }}</v-card-title>
+        <v-list>
+          <v-list-item :href="version.url +'userguide/'">User Guide</v-list-item>
+          <v-list-item :href="version.url +'developerguide/'">Developer Guide</v-list-item>
+          <v-list-item :href="version.url +'api-c++/'">C++ API</v-list-item>
+          <v-list-item :href="version.url +'api-python/'">Python API</v-list-item>
+        </v-list>
+      </v-card>
+    </v-container>
+
+
+
   </div>
 </template>
 
@@ -198,3 +219,16 @@
     height:100%;
   }
 </style>
+
+
+<script>
+module.exports = {
+  data: function() { return {
+    versions: [],
+    latest: ''
+  }},
+  created: function() {
+    fetch('data/versions.json').then(res => res.json()).then(versions => this.versions = versions, latest => this.latests = latest)
+  }
+}
+</script>

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,0 +1,61 @@
+{
+    "latest": "8.0.0",
+    "versions":[
+    {
+        "name": "development",
+        "url": "http://docs.openmm.org/development/"
+    },
+    {
+        "name": "latest (8.0.0)",
+        "url": "http://docs.openmm.org/latest/"
+    },
+    {
+        "name": "8.0.0",
+        "url": "http://docs.openmm.org/8.0.0/"
+    },
+    {
+        "name": "7.7.0",
+        "url": "http://docs.openmm.org/7.7.0/"
+    },
+    {
+        "name": "7.6.0",
+        "url": "http://docs.openmm.org/7.6.0/"
+    },
+    {
+        "name": "7.5.0",
+        "url": "http://docs.openmm.org/7.5.0/"
+    },
+    {
+        "name": "7.4.0",
+        "url": "http://docs.openmm.org/7.4.0/"
+    },
+    {
+        "name": "7.3.0",
+        "url": "http://docs.openmm.org/7.3.0/"
+    },
+    {
+        "name": "7.2.0",
+        "url": "http://docs.openmm.org/7.2.0/"
+    },
+    {
+        "name": "7.1.0",
+        "url": "http://docs.openmm.org/7.1.0/"
+    },
+    {
+        "name": "7.0.0",
+        "url": "http://docs.openmm.org/7.0.0/"
+    },
+    {
+        "name": "6.3.0",
+        "url": "http://docs.openmm.org/6.3.0/"
+    },
+    {
+        "name": "6.2.0",
+        "url": "http://docs.openmm.org/6.2.0/"
+    },
+    {
+        "name": "6.1.0",
+        "url": "http://docs.openmm.org/6.1.0/"
+    }
+    ]
+}


### PR DESCRIPTION
This PR adds a list with links to all available documentation versions. It is related to https://github.com/openmm/openmm/issues/3992

The list is generated from `data/versions.json`. When a new release is made this will need to be manually updated.

Can be viewed here: https://sef43.github.io/openmm-org/documentation