### PR TITLE
URL for new forum

### DIFF
--- a/components/documentation.vue
+++ b/components/documentation.vue
@@ -101,16 +101,10 @@
           Report bugs and request features. Please describe clearly what you want to achieve.
         </v-card-text>
       </v-card>
-      <v-card href="https://simtk.org/forums/viewforum.php?f=161" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>Forum (old)</v-card-title>
+      <v-card href="https://github.com/openmm/openmm/discussions" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>Forum</v-card-title>
         <v-card-text>
-          General discussion how to use OpenMM.
-        </v-card-text>
-      </v-card>
-      <v-card href="http://wiki.simtk.org/openmm/Hardware" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>Hardware (old)</v-card-title>
-        <v-card-text>
-          Hardware requiment and recommendations for OpenMM.
+          General discussion on using and developing OpenMM.
         </v-card-text>
       </v-card>
     </v-container>


### PR DESCRIPTION
Point to the new forum on github instead of the old one on simtk.org.