### PR TITLE
Update site content and links

### DIFF
--- a/components/development.vue
+++ b/components/development.vue
@@ -14,7 +14,7 @@
         <v-card-text>
           <ul>
             <li><a href="https://web.stanford.edu/group/markland/about.html" target="blank">Tom Markland</a></li>
-            <li><a href="https://simtk.org/users/peastman" target="blank">Peter Eastman</a></li>
+            <li><a href="https://github.com/peastman" target="blank">Peter Eastman</a></li>
             <li><a href="https://github.com/epretti" target="blank">Evan Pretti</a></li>
           </ul>
         </v-card-text>

--- a/components/documentation.vue
+++ b/components/documentation.vue
@@ -115,16 +115,32 @@
           If you use OpenMM for scientific research, please cite it.
         </v-card-text>
       </v-card>
-    </v-container>
-    <v-container class="d-flex flex-wrap justify-center">
-      <v-card href="https://doi.org/10.1021/acs.jpcb.3c06662" target="blank" class="ma-4" hover>
+      <v-card flat>
         <v-card-text>
-          Peter Eastman, Raimondas Galvelis, Raúl P. Peláez, Charlles R. A. Abreu, Stephen E. Farr, Emilio Gallicchio, Anton Gorenko, Michael M. Henry, Frank Hu, Jing Huang, Andreas Krämer, Julien Michel, Joshua A. Mitchell, Vijay S. Pande, João PGLM Rodrigues, Jaime Rodriguez-Guerra, Andrew C. Simmonett, Sukrit Singh, Jason Swails, Philip Turner, Yuanqing Wang, Ivy Zhang, John D. Chodera, Gianni De Fabritiis, and Thomas E. Markland. "OpenMM 8: Molecular Dynamics Simulation with Machine Learning Potentials." J. Phys. Chem. B 128(1), pp. 109-116 (2023). DOI: <a href="https://doi.org/10.1021/acs.jpcb.3c06662" target="blank">10.1021/acs.jpcb.3c06662</a>
+          <b>Primary Publication:</b>
+          <ul>
+            <li>Peter Eastman, Raimondas Galvelis, Raúl P. Peláez, Charlles R. A. Abreu, Stephen E. Farr, Emilio Gallicchio, Anton Gorenko, Michael M. Henry, Frank Hu, Jing Huang, Andreas Krämer, Julien Michel, Joshua A. Mitchell, Vijay S. Pande, João PGLM Rodrigues, Jaime Rodriguez-Guerra, Andrew C. Simmonett, Sukrit Singh, Jason Swails, Philip Turner, Yuanqing Wang, Ivy Zhang, John D. Chodera, Gianni De Fabritiis, and Thomas E. Markland. "OpenMM 8: Molecular Dynamics Simulation with Machine Learning Potentials." J. Phys. Chem. B 128(1), pp. 109-116 (2023). DOI: <a href="https://doi.org/10.1021/acs.jpcb.3c06662" target="blank">10.1021/acs.jpcb.3c06662</a></li>
+          </ul>
         </v-card-text>
       </v-card>
+      <v-expand-transition>
+        <v-card v-show="expand_publications" flat>
+          <v-card-text>
+            <b>Additional Publications:</b>
+            <ul>
+              <li>Peter Eastman, Jason Swails, John D. Chodera, Robert T. McGibbon, Yutong Zhao, Kyle A. Beauchamp, Lee-Ping Wang, Andrew C. Simmonett, Matthew P. Harrigan, Chaya D. Stern, Rafal P. Wiewiora, Bernard R. Brooks, and Vijay S. Pande. "OpenMM 7: Rapid development of high performance algorithms for molecular dynamics." PLOS Comput. Biol. 13(7): e1005659 (2017). DOI: <a href="https://doi.org/10.1371/journal.pcbi.1005659" target="blank">10.1371/journal.pcbi.1005659</a></li>
+              <li>Peter Eastman, Mark S. Friedrichs, John D. Chodera, Randall J. Radmer, Christopher M. Bruns, Joy P. Ku, Kyle A. Beauchamp, Thomas J. Lane, Lee-Ping Wang, Diwakar Shukla, Tony Tye, Mike Houston, Timo Stich, Christoph Klein, Michael R. Shirts, and Vijay S. Pande. "OpenMM 4: A Reusable, Extensible, Hardware Independent Library for High Performance Molecular Simulation." J. Chem. Theory Comput. 9(1):461-469 (2013). DOI: <a href="https://doi.org/10.1021/ct300857j" target="blank">10.1021/ct300857j</a></li>
+              <li>Peter Eastman and Vijay S. Pande. "OpenMM: A Hardware-Independent Framework for Molecular Simulations." Comput. Sci. Eng., 12:34-39 (2010).  DOI: <a href="https://doi.org/10.1109/MCSE.2010.27" target="blank">10.1109/MCSE.2010.27</a></li>
+              <li>Peter Eastman and Vijay S. Pande. "Efficient Nonbonded Interactions for Molecular Dynamics on a Graphics Processing Unit." J. Comput. Chem. 31:1268-72 (2010). DOI: <a href="https://doi.org/10.1002/jcc.21413" target="blank">10.1002/jcc.21413</a></li>
+              <li>Peter Eastman and Vijay S. Pande. "Constant Constraint Matrix Approximation: A Robust, Parallelizable Constraint Method for Molecular Simulations." J. Chem. Theory Comput. 6:434-437 (2010). DOI: <a href="https://doi.org/10.1021/ct900463w" target="blank">10.1021/ct900463w</a></li>
+              <li>Mark S. Friedrichs, Peter Eastman, Vishal Vaidyanathan, Mike Houston, Scott Legrand, Adam L. Beberg, Daniel L. Ensign, Christopher M. Bruns, Vijay S. Pande. "Accelerating Molecular Dynamic Simulation on Graphics Processing Units." J. Comput. Chem., 30(6):864-872 (2009). DOI: <a href="https://doi.org/10.1002/jcc.21209" target="blank">10.1002/jcc.21209</a></li>
+            </ul>
+          </v-card-text>
+        </v-card>
+      </v-expand-transition>
     </v-container>
     <v-container class="d-flex justify-center">
-      <v-btn href="https://simtk.org/plugins/publications/index.php/?group_id=161" target="blank">More publications</v-btn>
+      <v-btn @click="expand_publications = !expand_publications">{{ expand_publications_text }}</v-btn>
     </v-container>
     <v-container>
       <v-card flat>
@@ -192,3 +208,18 @@
     height:100%;
   }
 </style>
+
+<script>
+module.exports = {
+  data: function() {
+    return {
+      expand_publications: false
+    };
+  },
+  computed: {
+    expand_publications_text: function() {
+      return this.expand_publications ? "Hide Additional Publications" : "Show Additional Publications";
+    }
+  }
+}
+</script>

--- a/components/documentation.vue
+++ b/components/documentation.vue
@@ -54,9 +54,31 @@
     </v-container>
     <v-container>
       <v-card flat>
+        <v-card-title>Support</v-card-title>
+        <v-card-text>
+          For bug reports, feature requests, specific questions, etc.
+        </v-card-text>
+      </v-card>
+    </v-container>
+    <v-container class="d-flex flex-wrap justify-center">
+      <v-card href="https://github.com/openmm/openmm/issues" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>Issue Tracker</v-card-title>
+        <v-card-text>
+          Report bugs and request features. Please describe clearly what you want to achieve.
+        </v-card-text>
+      </v-card>
+      <v-card href="https://github.com/openmm/openmm/discussions" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>Forum</v-card-title>
+        <v-card-text>
+          General discussion on using and developing OpenMM.
+        </v-card-text>
+      </v-card>
+    </v-container>
+    <v-container>
+      <v-card flat>
         <v-card-title>Workshop Videos</v-card-title>
         <v-card-text>
-           Every year, we hold several OpenMM workshops at Stanford University. After you have successfully installed OpenMM, here are some introductory videos from previous workshops.
+           After you have successfully installed OpenMM, here are some introductory videos from previous OpenMM workshops held at Stanford University.
         </v-card-text>
       </v-card>
     </v-container>
@@ -83,28 +105,6 @@
           <div class="video-container">
             <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLGL4XGw8noUwrh16gsC9H_D03fED3IcHo" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
           </div>
-        </v-card-text>
-      </v-card>
-    </v-container>
-    <v-container>
-      <v-card flat>
-        <v-card-title>Support</v-card-title>
-        <v-card-text>
-          For bug reports, feature requests, specific questions, etc.
-        </v-card-text>
-      </v-card>
-    </v-container>
-    <v-container class="d-flex flex-wrap justify-center">
-      <v-card href="https://github.com/openmm/openmm/issues" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>Issue Tracker</v-card-title>
-        <v-card-text>
-          Report bugs and request features. Please describe clearly what you want to achieve.
-        </v-card-text>
-      </v-card>
-      <v-card href="https://github.com/openmm/openmm/discussions" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>Forum</v-card-title>
-        <v-card-text>
-          General discussion on using and developing OpenMM.
         </v-card-text>
       </v-card>
     </v-container>

--- a/components/ecosystem.vue
+++ b/components/ecosystem.vue
@@ -41,6 +41,12 @@
           A distributed computing infrastructure devoted to biomedical research to understand the function of biomolecules for health and disease.
         </v-card-text>
       </v-card>
+      <v-card href="https://github.com/pandegroup/pdbfixer/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>PDBFixer</v-card-title>
+        <v-card-text>
+          A powerful, flexible tool for preparing PDB files for molecular simulation or modeling, capable of running in interactive, Python-scriptable, or fully automated modes.
+        </v-card-text>
+      </v-card>
       <v-card href="https://siremol.org/" target="blank" class="ma-4" width="300" hover>
         <v-card-title>SireMol</v-card-title>
         <v-card-text>
@@ -136,12 +142,6 @@
         <v-card-title>OpenMM-XTB</v-card-title>
         <v-card-text>
           A plugin providing a connection between OpenMM and the XTB quantum chemistry package.
-        </v-card-text>
-      </v-card>
-      <v-card href="https://github.com/pandegroup/pdbfixer/" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>PDBFixer</v-card-title>
-        <v-card-text>
-          A powerful, flexible tool for preparing PDB files for molecular simulation or modeling, capable of running in interactive, Python-scriptable, or fully automated modes.
         </v-card-text>
       </v-card>
       <v-card href="https://simtk.org/svn/pyopenmm/trunk/simtk/pyopenmm/extras/optimizepme.py" target="blank" class="ma-4" width="300" hover>

--- a/components/ecosystem.vue
+++ b/components/ecosystem.vue
@@ -41,12 +41,6 @@
           A distributed computing infrastructure devoted to biomedical research to understand the function of biomolecules for health and disease.
         </v-card-text>
       </v-card>
-      <v-card href="https://github.com/pandegroup/pdbfixer/" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>PDBFixer</v-card-title>
-        <v-card-text>
-          A powerful, flexible tool for preparing PDB files for molecular simulation or modeling, capable of running in interactive, Python-scriptable, or fully automated modes.
-        </v-card-text>
-      </v-card>
       <v-card href="https://siremol.org/" target="blank" class="ma-4" width="300" hover>
         <v-card-title>SireMol</v-card-title>
         <v-card-text>
@@ -84,16 +78,34 @@
       </v-card>
     </v-container>
     <v-container class="d-flex flex-wrap justify-center">
-      <v-card href="https://github.com/openmm/openmm-torch/" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>OpenMM-Torch</v-card-title>
+      <v-card href="https://github.com/openmm/openmmforcefields/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>openmmforcefields</v-card-title>
         <v-card-text>
-          A plugin for OpenMM that allows PyTorch models to be used for defining an OpenMM force object.
+          OpenMM support for AMBER, CHARMM, OpenFF, and Espaloma force fields, and small molecule parameterization with GAFF, Espaloma and the OpenFF Toolkit.
+        </v-card-text>
+      </v-card>
+      <v-card href="https://github.com/leeping/OpenMM-MD/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>OpenMM-MD</v-card-title>
+        <v-card-text>
+           A general purpose script (with lots of comments) that uses the OpenMM Python module to drive MD simulations. Simulation options are handled via an input file.
+        </v-card-text>
+      </v-card>
+      <v-card href="https://github.com/openmm/openmm-ml/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>OpenMM-ML</v-card-title>
+        <v-card-text>
+          A high-level API for using machine learning models, including ANI-1ccx, ANI-2x, and MACE-OFF23, in OpenMM simulations.
         </v-card-text>
       </v-card>
       <v-card href="https://github.com/openmm/openmm-plumed/" target="blank" class="ma-4" width="300" hover>
         <v-card-title>OpenMM-PLUMED</v-card-title>
         <v-card-text>
           Provides a connection between OpenMM and PLUMED. It allows you to bias or analyze an OpenMM simulation based on collective variables.
+        </v-card-text>
+      </v-card>
+      <v-card href="https://github.com/openmm/openmm-setup" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>OpenMM Setup</v-card-title>
+        <v-card-text>
+          A graphical application to set up and run simulations with OpenMM. Includes pull-down menus, pop-up tips, error checking, and live script building
         </v-card-text>
       </v-card>
       <v-card href="https://github.com/openmm/openmm-tensorflow/" target="blank" class="ma-4" width="300" hover>
@@ -108,10 +120,16 @@
           This is a plugin for OpenMM that allows neural networks to be used for defining forces. It is implemented with TensorRT.
         </v-card-text>
       </v-card>
-      <v-card href="https://github.com/openmm/openmm-ml/" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>OpenMM-ML</v-card-title>
+      <v-card href="https://openmmtools.readthedocs.io/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>OpenMMTools</v-card-title>
         <v-card-text>
-          A high-level API for using machine learning models, including ANI-1ccx, ANI-2x, and MACE-OFF23, in OpenMM simulations.
+          Integrators, enhanced sampling methods, test systems, and alchemical factories for OpenMM.
+        </v-card-text>
+      </v-card>
+      <v-card href="https://github.com/openmm/openmm-torch/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>OpenMM-Torch</v-card-title>
+        <v-card-text>
+          A plugin for OpenMM that allows PyTorch models to be used for defining an OpenMM force object.
         </v-card-text>
       </v-card>
       <v-card href="https://github.com/openmm/openmm-xtb/" target="blank" class="ma-4" width="300" hover>
@@ -120,28 +138,10 @@
           A plugin providing a connection between OpenMM and the XTB quantum chemistry package.
         </v-card-text>
       </v-card>
-      <v-card href="https://github.com/openmm/openmmforcefields/" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>openmmforcefields</v-card-title>
+      <v-card href="https://github.com/pandegroup/pdbfixer/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>PDBFixer</v-card-title>
         <v-card-text>
-          OpenMM support for AMBER, CHARMM, OpenFF, and Espaloma force fields, and small molecule parameterization with GAFF, Espaloma and the OpenFF Toolkit.
-        </v-card-text>
-      </v-card>
-      <v-card href="https://openmmtools.readthedocs.io/" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>OpenMMTools</v-card-title>
-        <v-card-text>
-          Integrators, enhanced sampling methods, test systems, and alchemical factories for OpenMM.
-        </v-card-text>
-      </v-card>
-      <v-card href="https://github.com/openmm/openmm-setup" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>OpenMM Setup</v-card-title>
-        <v-card-text>
-          A graphical application to set up and run simulations with OpenMM. Includes pull-down menus, pop-up tips, error checking, and live script building
-        </v-card-text>
-      </v-card>
-      <v-card href="https://github.com/leeping/OpenMM-MD/" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>OpenMM-MD</v-card-title>
-        <v-card-text>
-           A general purpose script (with lots of comments) that uses the OpenMM Python module to drive MD simulations. Simulation options are handled via an input file.
+          A powerful, flexible tool for preparing PDB files for molecular simulation or modeling, capable of running in interactive, Python-scriptable, or fully automated modes.
         </v-card-text>
       </v-card>
       <v-card href="https://simtk.org/svn/pyopenmm/trunk/simtk/pyopenmm/extras/optimizepme.py" target="blank" class="ma-4" width="300" hover>

--- a/components/ecosystem.vue
+++ b/components/ecosystem.vue
@@ -75,10 +75,11 @@
     </v-container>
     <v-container>
       <v-card flat>
-        <v-card-title>OpenMM Plugins</v-card-title>
+        <v-card-title>OpenMM Tools and Plugins</v-card-title>
         <v-card-text>
-          Expand OpenMM capabilities by interfacing with other software. The plugins are developed
-          and released independetly from OpenMM.
+          Resources that make it easier to use OpenMM, and plugins that expand
+          OpenMM capabilities by interfacing with other software. The plugins
+          are developed and released independently from OpenMM.
         </v-card-text>
       </v-card>
     </v-container>
@@ -95,12 +96,6 @@
           Provides a connection between OpenMM and PLUMED. It allows you to bias or analyze an OpenMM simulation based on collective variables.
         </v-card-text>
       </v-card>
-      <v-card href="https://github.com/amd/openmm-hip" target="blank" class="ma-4" width="300" hover>
-        <v-card-title>OpenMM-HIP</v-card-title>
-        <v-card-text>
-          A high performance OpenMM platform for AMD GPUs.
-        </v-card-text>
-      </v-card>
       <v-card href="https://github.com/openmm/openmm-tensorflow/" target="blank" class="ma-4" width="300" hover>
         <v-card-title>OpenMM-TensorFlow</v-card-title>
         <v-card-text>
@@ -113,16 +108,24 @@
           This is a plugin for OpenMM that allows neural networks to be used for defining forces. It is implemented with TensorRT.
         </v-card-text>
       </v-card>
-    </v-container>
-    <v-container>
-      <v-card flat>
-        <v-card-title>OpenMM Tools</v-card-title>
+      <v-card href="https://github.com/openmm/openmm-ml/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>OpenMM-ML</v-card-title>
         <v-card-text>
-          Resources that make it easier to use OpenMM.
+          A high-level API for using machine learning models, including ANI-1ccx, ANI-2x, and MACE-OFF23, in OpenMM simulations.
         </v-card-text>
       </v-card>
-    </v-container>
-    <v-container class="d-flex flex-wrap justify-center">
+      <v-card href="https://github.com/openmm/openmm-xtb/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>OpenMM-XTB</v-card-title>
+        <v-card-text>
+          A plugin providing a connection between OpenMM and the XTB quantum chemistry package.
+        </v-card-text>
+      </v-card>
+      <v-card href="https://github.com/openmm/openmmforcefields/" target="blank" class="ma-4" width="300" hover>
+        <v-card-title>openmmforcefields</v-card-title>
+        <v-card-text>
+          OpenMM support for AMBER, CHARMM, OpenFF, and Espaloma force fields, and small molecule parameterization with GAFF, Espaloma and the OpenFF Toolkit.
+        </v-card-text>
+      </v-card>
       <v-card href="https://openmmtools.readthedocs.io/" target="blank" class="ma-4" width="300" hover>
         <v-card-title>OpenMMTools</v-card-title>
         <v-card-text>

--- a/components/home.vue
+++ b/components/home.vue
@@ -46,22 +46,6 @@
     </v-container>
     <v-container>
       <v-card flat>
-        <v-card-title>Announcements</v-card-title>
-      </v-card>
-    </v-container>
-    <v-container class="d-flex justify-center">
-      <v-card href="https://www.compscience.org/assets/jobs/PDPHD2021MD.pdf" target="blank" class="ma-4" width="800" hover>
-        <v-card-title>PhD and post-doctoral positions</v-card-title>
-        <v-card-text>
-          We are looking to recruit multiple positions at PhD and post-doctoral levels to work
-          on OpenMM.
-          The projects are about the next generation molecular simulations and neural network potentials.
-          The positions are at the Computational Science Laboratory, University Pompeu Fabra, Barcelona.
-        </v-card-text>
-      </v-card>
-    </v-container>
-    <v-container>
-      <v-card flat>
         <v-card-title>The Power of Python Scripting</v-card-title>
         <v-card-text>
           Use Python scripting to create your own simulation protocols in just a few lines of code.

--- a/data/people.json
+++ b/data/people.json
@@ -10,7 +10,7 @@
     },
     {
         "name": "Peter Eastman (Stanford University)",
-        "url": "https://simtk.org/users/peastman"
+        "url": "https://github.com/peastman"
     },
     {
         "name": "Gianni de Fabritiis (Universitat Pompeu Fabra)",


### PR DESCRIPTION
Updates some links that were pointing to SimTK or otherwise outdated.  Please take a look and note:

- Publications in addition to the latest one are now in an expandable panel.  Any missing citations can be added.
- List on the Ecosystem page has been updated.  PME Optimizer still works, after updating from Python 2 syntax.  Do we want that in a repository somewhere (maybe even just in this one, left in the `data` directory) so it's not pointing to a file hosted by SimTK?

Preview at <https://epretti.github.io/openmm-org/>.  There are some oddities with the website when hosting in a non-root directory (accessing URLs to pages other than the home page don't work properly, and you may need to clear the browser cache to get it to update some pages).  But it should be visible, and these issues don't appear when hosting locally.